### PR TITLE
Perform migrations after setting up SNOMED

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,7 +64,7 @@ pipeline {
                                     sh '''
                                         source docker/vars.local.tests.sh
                                         docker-compose -f docker/docker-compose.yml up -d ps_db
-                                        docker-compose -f docker/docker-compose.yml up db_migration
+
                                         aws s3 cp s3://snomed-schema/uk_sct2mo_39.0.0_20240925000001Z.zip ./snomed-database-loader/uk_sct2mo_39.0.0_20240925000001Z.zip
                                         # As Jenkins is running inside of Docker too, can't just reference the snomed file as a volume as part of the docker run command
                                         # Instead copy the file into a named volume first as a separate docker command
@@ -72,6 +72,8 @@ pipeline {
                                         cat ./snomed-database-loader/uk_sct2mo_39.0.0_20240925000001Z.zip | docker run --rm --interactive -v snomed:/snomed alpine sh -c "cat > /snomed/uk_sct2mo_39.0.0_20240925000001Z.zip"
                                         docker-compose -f docker/docker-compose.yml run --rm --volume snomed:/snomed snomed_schema /snomed/uk_sct2mo_39.0.0_20240925000001Z.zip
                                         docker volume rm snomed
+
+                                        docker-compose -f docker/docker-compose.yml up db_migration
                                     '''
                                 }
                             }


### PR DESCRIPTION
## Why

This will allow us to potentially cache the DB image containing a SNOMED dump, speeding up the build process.

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation