### PR TITLE
Rename adaptor from patient switching to GP2GP FHIR Request Adaptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 > [!NOTE]
 > **Upgrade information** This release includes an update to the SNOMED database
-> Users will need to perform an [update of their patient switching SNOMED database](OPERATING.md#updating-the-snomed-database).
+> Users will need to perform an [update of their SNOMED database](OPERATING.md#updating-the-snomed-database).
 > This will need to be performed first, followed by deploying the updated version of the translator image.
 
 ## Added
@@ -320,7 +320,7 @@ corresponding FHIR resource will now be [appropriately populated][nopat-docs].
 
 > [!NOTE]
 > **Upgrade information** This release includes an update to the SNOMED database
-> Users will need to perform an [update of their patient switching SNOMED database](OPERATING.md#updating-the-snomed-database).
+> Users will need to perform an [update of their SNOMED database](OPERATING.md#updating-the-snomed-database).
 > This will need to be performed first, followed by deploying the updated version of the translator image.
 
 ## [1.4.2] - 2024-01-31
@@ -400,7 +400,7 @@ corresponding FHIR resource will now be [appropriately populated][nopat-docs].
 > [!NOTE]
 > **Upgrade information** This release includes a [database migration](OPERATING.md#updating-the-application-schema).
 > This database migration will need to be performed first, followed by deploying the updated version of the facade and translator images.
-> Finally users will need to perform an [update of their patient switching SNOMED database](OPERATING.md#updating-the-snomed-database).
+> Finally users will need to perform an [update of their SNOMED database](OPERATING.md#updating-the-snomed-database).
 
 ## [1.0.1] - 2023-11-21
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nia-patient-switching-standard-adaptor
+# GP2GP FHIR Request Adaptor
 National Integration Adaptor - [GP2GP Requesting Adaptor](https://digital.nhs.uk/developer/api-catalogue/gp2gp/patient-switching---integration-adaptor)
 
 Incumbent providers (e.g. TPP, EMIS, SystemOne) in order to deploy GP2GP Adaptor in their infrastructure
@@ -7,7 +7,7 @@ would have to make changes to their GP Connect interface implementations.
 In particular, they would need to implement 1.6.0 version that is required by the GPC Consumer and GP2GP adaptors.
 This business case is not always easy to be accepted by the incumbent providers, as they would have to invest time to make those changes.
 
-The motivation for the Switching Standard Adaptor is to remove the dependency from incumbent providers to do that work.
+The motivation for the GP2GP FHIR Request   Adaptor is to remove the dependency from incumbent providers to do that work.
 The idea is to build an adaptor that could be installed and configured in a New Market Entrant (NME) infrastructure,
 and could work with the incumbent’s GPC < 1.6.0.
 
@@ -28,7 +28,7 @@ Both are Java Spring Boot applications, released as separate docker images.
 
 ## Endpoints
 
-The Patient Switching Adaptor's facade provides two main endpoints for interacting with patient records.
+The Adaptor's facade provides two main endpoints for interacting with patient records.
 
 ### POST /Patient/$gpc.migratestructuredrecord
 
@@ -171,16 +171,16 @@ The contents of this repository are protected by Crown Copyright (C).
 
 Case 1: Performance Testing with JMeter
 
-We conducted a performance test of the PS Adaptor using the JMeter tool. 
+We conducted a performance test of the Adaptor using the JMeter tool. 
 The use case focused on simulating a patient transfer request, 
-where Electronic Health Record (EHR) requests were sent to the PS Adaptor, expecting a bundle in return. 
+where Electronic Health Record (EHR) requests were sent to the Adaptor, expecting a bundle in return. 
 This test involved two text attachments with sizes of 2.44 MB and 0.7 MB, respectively. 
-The primary goal was to evaluate how the PS Adaptor manages a heavy workload and to monitor CPU and memory usage 
+The primary goal was to evaluate how the Adaptor manages a heavy workload and to monitor CPU and memory usage 
 during the process.
 
 Test Setup and Parameters:
 
- - PS Adaptor: Deployed in an ECS AWS environment with 4 CPUs and 16 GB of memory (shared between the PS Translator and Facade).
+ - GP2GP FHIR Request Adaptor: Deployed in an ECS AWS environment with 4 CPUs and 16 GB of memory (shared between the PS Translator and Facade).
  - MHS Adaptor: Deployed in an ECS AWS environment with 4 CPUs and 16 GB of memory (shared between inbound and outbound).
  - Message Queue: Utilized the mq.m5.xlarge instance type.
  - RDS Database: Hosted on a db.t3.xlarge instance.
@@ -205,7 +205,7 @@ These tests were conducted with TPP/EMIS as the sending systems and Medicus as t
 
 Resource Allocation:
 
-PS Adaptor:
+GP2GP FHIR Request Adaptor:
     Facade: 2 vCPUs, 4 GB RAM
     Translator: 2 vCPUs, 4 GB RAM
 MHS Adaptor:


### PR DESCRIPTION
## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation