### PR TITLE
Document MHS_FORWARD_RELIABLE_ENDPOINT_URL in getting-started-instructions

### DIFF
--- a/getting-started-instructions.md
+++ b/getting-started-instructions.md
@@ -28,7 +28,10 @@ This is a __required__ prerequisite for both requesting and sending adaptors.
    MIIFhzCC...
    -----END CERTIFICATE-----
    ```
+1. Specify the `MHS_FORWARD_RELIABLE_ENDPOINT_URL` environment variable for Inbound/Outbound adaptors set to the value
+   specified by the [Integration Environment - Messaging URLs][messaging-urls] "Used for all domain reliable messaging".
 
+[messaging-urls]: https://digital.nhs.uk/services/path-to-live-environments/integration-environment#messaging-urls
 [spine-certificates]: https://digital.nhs.uk/services/path-to-live-environments/integration-environment#rootca-and-subca-certificates
 
 ### Requesting adaptor


### PR DESCRIPTION
## Why

It appears this needs to be set for the MHS adaptor to work.

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation