### PR TITLE
Make BuildId comment job only run on pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,7 @@ jobs:
     secrets: inherit
 
   comment:
+    if: github.event_name == 'pull_request'
     name: "Create Build ID Comment"
     needs: [ generate-build-id, publish-docker-images]
     continue-on-error: true


### PR DESCRIPTION
## What

Make the buildId comment only run on PR, not when merging to main

## Why

The buildId comment attempts to create a comment on the PR when merging to main.  This step should only run against the PR or it will report an error

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation