### PR TITLE
Prevent Dependabot running mutation testing

### DIFF
--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   gp2gp-translator-mutation-testing:
     name: "Mutation Testing"
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     strategy:
       matrix:
         path: [ ./gpc-api-facade, ./gp2gp-translator]


### PR DESCRIPTION
## What

Add an if condition to the mutation testing GitHub action to prevent the mutation testing from being run if the GitHub actor is dependabot.

## Why

Currently the mutation testing workflow triggers when dependabot raises a PR.  This fails as Dependabot does not have access to GitHub secrets

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation