### PR TITLE
Fix issue with duplicate Build ID comments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,5 +114,6 @@ jobs:
         with:
           message: |
             Images built and published to ECR using a Build Id of ${{ needs.generate-build-id.outputs.build-id }}
-        
+          comment_tag: images-built
+          mode: upsert
 


### PR DESCRIPTION
## What

Ensure that the comment showing the build ID is updated and a new one is not created when a PR is rebuilt

## Why

Each time a PR was re-run, then a new build ID comment was posted.  If the comment exists it should be amended with the latest successful build ID instead

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation