### PR TITLE
Run checkstyle and spotbugs against IntegrationTest in github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           ./gradlew checkStyleMain --parallel
           ./gradlew checkstyleTest --parallel
+          /gradlew checkstyleIntegrationTest --parallel
         working-directory: ${{ inputs.path }}
 
       - name: Collect Artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,16 +23,8 @@ jobs:
           java-version: 21
           distribution: 'temurin'
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          add-job-summary: "on-failure"
-
       - name: Execute Checkstyle
-        run: |
-          ./gradlew checkStyleMain --parallel
-          ./gradlew checkstyleTest --parallel
-          ./gradlew checkstyleIntegrationTest --parallel
+        run: ./gradlew checkStyleMain checkstyleTest checkstyleIntegrationTest
         working-directory: ${{ inputs.path }}
 
       - name: Collect Artifacts
@@ -65,16 +57,8 @@ jobs:
           java-version: 21
           distribution: 'temurin'
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          add-job-summary: "on-failure"
-
       - name: Execute Spotbugs
-        run: |
-          ./gradlew spotbugsMain --parallel
-          ./gradlew spotbugsTest --parallel
-          ./gradlew spotbugsIntegrationTest --parallel
+        run: ./gradlew spotbugsMain spotbugsTest spotbugsIntegrationTest
         working-directory: ${{ inputs.path }}
 
       - name: Collect Artifacts
@@ -107,11 +91,6 @@ jobs:
         with:
           java-version: 21
           distribution: 'temurin'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          add-job-summary: "on-failure"
 
       - name: Execute Unit Tests
         run: ./gradlew test --parallel --build-cache
@@ -202,11 +181,6 @@ jobs:
           PS_DB_HOST: "localhost"
           PS_DB_PORT: "5436"
         run: ./test-load-immunization-codes.sh
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          add-job-summary: "on-failure"
 
       - name: Execute Integration Tests
         working-directory: ${{ inputs.path }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           ./gradlew checkStyleMain --parallel
           ./gradlew checkstyleTest --parallel
-          /gradlew checkstyleIntegrationTest --parallel
+          ./gradlew checkstyleIntegrationTest --parallel
         working-directory: ${{ inputs.path }}
 
       - name: Collect Artifacts
@@ -74,6 +74,7 @@ jobs:
         run: |
           ./gradlew spotbugsMain --parallel
           ./gradlew spotbugsTest --parallel
+          ./gradlew spotbugsIntegrationTest --parallel
         working-directory: ${{ inputs.path }}
 
       - name: Collect Artifacts


### PR DESCRIPTION
## What

Added checkstylentegrationTests and spotbugsIntegrationTests to github `Test` action

## Why

Checkstyle and SpotBugs were not running against the integration tests.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation