### PR TITLE
Accept a "resent" EHR Extract from an incumbent as per the spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+* In the event of patient migration request which has failed, the adaptor would previously reject an XML Electronic
+  Health Record which had been resent to it.
+  Now the adaptor will instead accept the resent EHR and perform the translation to FHIR.
 * When sending a negative acknowledgement to the sending system in the event of a failure, include the textual
   description of the reason, e.g. "EHR Extract message not well-formed or not able to be processed".
   This behaviour while not required by the spec, has been implemented by other GP2GP systems, and is expected to be

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/FailedProcessHandlingIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/FailedProcessHandlingIT.java
@@ -36,21 +36,6 @@ public class FailedProcessHandlingIT extends BaseEhrHandler {
     private MigrationStatusLogService migrationStatusLogService;
 
     @Test
-    public void When_ProcessFailedByIncumbent_With_EhrExtract_Expect_NotProcessed() {
-        sendNackToQueue();
-
-        await().until(() -> isMigrationStatus(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_UNKNOWN));
-
-        sendEhrExtractToQueue();
-
-        await().until(() -> hasNackBeenSentWithCode(UNEXPECTED_CONDITION_CODE));
-
-        var migrationStatus = migrationStatusLogService.getLatestMigrationStatusLog(getConversationId()).getMigrationStatus();
-
-        assertThat(migrationStatus).isEqualTo(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_UNKNOWN);
-    }
-
-    @Test
     public void When_ProcessFailedByIncumbent_With_CopcMessage_Expect_NotProcessed() {
         sendEhrExtractToQueue();
 
@@ -67,19 +52,6 @@ public class FailedProcessHandlingIT extends BaseEhrHandler {
         var migrationStatus = migrationStatusLogService.getLatestMigrationStatusLog(getConversationId()).getMigrationStatus();
 
         assertThat(migrationStatus).isEqualTo(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_UNKNOWN);
-    }
-
-    @Test
-    public void When_ProcessFailedByNME_With_EhrExtract_Expect_NotProcessed() {
-        migrationStatusLogService.addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR, getConversationId(), null, "99");
-
-        sendEhrExtractToQueue();
-
-        await().until(() -> hasNackBeenSentWithCode(UNEXPECTED_CONDITION_CODE));
-
-        var migrationStatus = migrationStatusLogService.getLatestMigrationStatusLog(getConversationId()).getMigrationStatus();
-
-        assertThat(migrationStatus).isEqualTo(EHR_GENERAL_PROCESSING_ERROR);
     }
 
     @Test

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/util/BaseEhrHandler.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/util/BaseEhrHandler.java
@@ -2,6 +2,7 @@ package uk.nhs.adaptors.pss.util;
 
 import static org.assertj.core.api.Assertions.fail;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static uk.nhs.adaptors.common.enums.MigrationStatus.EHR_EXTRACT_REQUEST_ACCEPTED;
 import static uk.nhs.adaptors.common.enums.MigrationStatus.EHR_EXTRACT_TRANSLATED;
 import static uk.nhs.adaptors.common.enums.MigrationStatus.MIGRATION_COMPLETED;
@@ -20,6 +21,7 @@ import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.assertj.core.api.ObjectAssert;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONException;
@@ -123,6 +125,11 @@ public abstract class BaseEhrHandler {
     protected boolean isMigrationStatus(MigrationStatus migrationStatus) {
         var migrationStatusLog = migrationStatusLogService.getLatestMigrationStatusLog(conversationId);
         return migrationStatus.equals(migrationStatusLog.getMigrationStatus());
+    }
+
+    @NotNull
+    protected ObjectAssert<MigrationStatus> assertThatMigrationStatus() {
+        return assertThat(migrationStatusLogService.getLatestMigrationStatusLog(getConversationId()).getMigrationStatus());
     }
 
     protected void verifyBundle(String path) throws JSONException {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/FailedProcessHandlingService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/FailedProcessHandlingService.java
@@ -25,7 +25,6 @@ import static uk.nhs.adaptors.pss.translator.model.NACKReason.UNEXPECTED_CONDITI
 import java.util.List;
 
 import org.hl7.v3.COPCIN000001UK01Message;
-import org.hl7.v3.RCMRIN030000UKMessage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -81,16 +80,6 @@ public class FailedProcessHandlingService {
         MigrationStatus migrationStatus = getMigrationStatus(conversationId);
 
         return FAILED_MIGRATION_STATUSES.contains(migrationStatus);
-    }
-
-    public void handleFailedProcess(RCMRIN030000UKMessage ehrExtractMessage, String conversationId) {
-        LOGGER.info("Received EHR Extract [Message ID: {}] but the transfer process has already failed. "
-                    + "Responding with NACK for unexpected condition.", ehrExtractMessage.getId().getRoot());
-
-        var nackMessageData = nackAckPreparationService
-            .prepareNackMessageData(UNEXPECTED_CONDITION, ehrExtractMessage, conversationId);
-
-        sendNACKMessageHandler.prepareAndSendMessage(nackMessageData);
     }
 
     public void handleFailedProcess(COPCIN000001UK01Message copcMessage, String conversationId) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandler.java
@@ -29,7 +29,6 @@ import uk.nhs.adaptors.pss.translator.model.ContinueRequestData;
 import uk.nhs.adaptors.pss.translator.service.AttachmentHandlerService;
 import uk.nhs.adaptors.pss.translator.service.AttachmentReferenceUpdaterService;
 import uk.nhs.adaptors.pss.translator.service.BundleMapperService;
-import uk.nhs.adaptors.pss.translator.service.FailedProcessHandlingService;
 import uk.nhs.adaptors.pss.translator.service.NackAckPrepInterface;
 import uk.nhs.adaptors.pss.translator.service.SkeletonProcessingService;
 import uk.nhs.adaptors.pss.translator.service.XPathService;
@@ -69,7 +68,6 @@ public class EhrExtractMessageHandler {
     private final XPathService xPathService;
     private final NackAckPrepInterface nackAckPreparationService;
     private final SkeletonProcessingService skeletonProcessingService;
-    private final FailedProcessHandlingService failedProcessHandlingService;
 
     private static final String MESSAGE_ID_PATH = "/Envelope/Header/MessageHeader/MessageData/MessageId";
 
@@ -86,11 +84,6 @@ public class EhrExtractMessageHandler {
         RCMRIN030000UKMessage payload = unmarshallString(inboundMessage.getPayload(), RCMRIN030000UKMessage.class);
         PatientMigrationRequest migrationRequest = migrationRequestDao.getMigrationRequest(conversationId);
         MigrationStatusLog migrationStatusLog = migrationStatusLogService.getLatestMigrationStatusLog(conversationId);
-
-        if (failedProcessHandlingService.hasProcessFailed(conversationId)) {
-            failedProcessHandlingService.handleFailedProcess(payload, conversationId);
-            return;
-        }
 
         migrationStatusLogService.addMigrationStatusLog(EHR_EXTRACT_RECEIVED, conversationId, null, null);
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/FailedProcessHandlingServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/FailedProcessHandlingServiceTest.java
@@ -15,7 +15,6 @@ import java.util.UUID;
 
 import org.hl7.v3.COPCIN000001UK01Message;
 import org.hl7.v3.II;
-import org.hl7.v3.RCMRIN030000UKMessage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -40,8 +39,6 @@ public class FailedProcessHandlingServiceTest {
     private MigrationStatusLogService migrationStatusLogService;
     @Mock
     private SendNACKMessageHandler sendNACKMessageHandler;
-    @Mock
-    private RCMRIN030000UKMessage ehrExtractMessage;
     @Mock
     private COPCIN000001UK01Message copcMessage;
     @Mock
@@ -84,19 +81,6 @@ public class FailedProcessHandlingServiceTest {
         boolean result = failedProcessHandlingService.hasProcessFailed(conversationId);
 
         assertThat(result).isTrue();
-    }
-
-    @Test
-    public void When_HandleFailedProcess_With_EhrExtract_Expect_UnexpectedCondition() {
-        String conversationId = UUID.randomUUID().toString();
-
-        when(ehrExtractMessage.getId()).thenReturn(mockId);
-        when(nackAckPreparationService.prepareNackMessageData(UNEXPECTED_CONDITION, ehrExtractMessage, conversationId))
-            .thenReturn(messageData);
-
-        failedProcessHandlingService.handleFailedProcess(ehrExtractMessage, conversationId);
-
-        verify(sendNACKMessageHandler).prepareAndSendMessage(messageData);
     }
 
     @ParameterizedTest

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandlerTest.java
@@ -67,7 +67,6 @@ import uk.nhs.adaptors.pss.translator.mhs.model.InboundMessage;
 import uk.nhs.adaptors.pss.translator.service.AttachmentHandlerService;
 import uk.nhs.adaptors.pss.translator.service.AttachmentReferenceUpdaterService;
 import uk.nhs.adaptors.pss.translator.service.BundleMapperService;
-import uk.nhs.adaptors.pss.translator.service.FailedProcessHandlingService;
 import uk.nhs.adaptors.pss.translator.service.NackAckPrepInterface;
 import uk.nhs.adaptors.pss.translator.service.SkeletonProcessingService;
 import uk.nhs.adaptors.pss.translator.service.XPathService;
@@ -130,8 +129,6 @@ public class EhrExtractMessageHandlerTest {
 
     @Mock
     private PatientAttachmentLog patientAttachmentLog;
-    @Mock
-    private FailedProcessHandlingService failedProcessHandlingService;
 
     @Captor
     private ArgumentCaptor<PatientAttachmentLog> patientAttachmentLogCaptor;
@@ -761,27 +758,6 @@ public class EhrExtractMessageHandlerTest {
         ehrExtractMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
         verify(patientAttachmentLogService, times(1)).addAttachmentLog(any());
-    }
-
-    @Test
-    @SneakyThrows
-    public void When_HandleMessage_With_ProcessHasFailed_Expect_FailureHandled()
-        throws AttachmentNotFoundException, JAXBException, BundleMappingException, ParseException,
-               JsonProcessingException, TransformerException, SAXException {
-
-        when(failedProcessHandlingService.hasProcessFailed(CONVERSATION_ID))
-            .thenReturn(true);
-
-        InboundMessage inboundMessage = new InboundMessage();
-        inboundMessage.setPayload(readInboundMessagePayloadFromFile());
-
-        ehrExtractMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
-
-        verify(failedProcessHandlingService, times(1))
-            .handleFailedProcess(any(RCMRIN030000UKMessage.class), eq(CONVERSATION_ID));
-
-        verify(migrationStatusLogService, times(0))
-            .addMigrationStatusLog(EHR_EXTRACT_RECEIVED, CONVERSATION_ID, null, null);
     }
 
     @SneakyThrows


### PR DESCRIPTION
## What

The GP2GP spec allows for an EHR Extract to be resent in the event of a failure.

## Why

This can be useful if there were temporary technical issues which caused the failure.

## Type of change

New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation