### PR TITLE
Add DNS resolution information to getting-started-information.md

### DIFF
--- a/getting-started-instructions.md
+++ b/getting-started-instructions.md
@@ -30,7 +30,11 @@ This is a __required__ prerequisite for both requesting and sending adaptors.
    ```
 1. Specify the `MHS_FORWARD_RELIABLE_ENDPOINT_URL` environment variable for Inbound/Outbound adaptors set to the value
    specified by the [Integration Environment - Messaging URLs][messaging-urls] "Used for all domain reliable messaging".
+   When specifying the URL you will need to provide the hostname provided by the Spine team.
+   This hostname will not be resolvable via public DNS however, so you will either need to either add the IP address
+   specified for the host into your `/etc/hosts` file or use the [HSCN DNS servers] for DNS resolution.
 
+[HSCN DNS servers]: https://digital.nhs.uk/services/health-and-social-care-network/hscn-technical-guidance/dns
 [messaging-urls]: https://digital.nhs.uk/services/path-to-live-environments/integration-environment#messaging-urls
 [spine-certificates]: https://digital.nhs.uk/services/path-to-live-environments/integration-environment#rootca-and-subca-certificates
 


### PR DESCRIPTION
## Why

Has been a source of confusion/pain for the NMEs when setting up the adaptor.

## Type of change

Documentation

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation