### PR TITLE
Add `responseText` to enum `NACKReason` to be used when populating the NACK response

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/model/NACKReason.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/model/NACKReason.java
@@ -13,26 +13,42 @@ import static uk.nhs.adaptors.common.enums.MigrationStatus.ERROR_LRG_MSG_REASSEM
 import static uk.nhs.adaptors.common.enums.MigrationStatus.ERROR_LRG_MSG_TIMEOUT;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import uk.nhs.adaptors.common.enums.MigrationStatus;
 
-@RequiredArgsConstructor
+@Getter
 public enum NACKReason {
 
-    LARGE_MESSAGE_REASSEMBLY_FAILURE("29"),
-    LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED("31"),
-    LARGE_MESSAGE_GENERAL_FAILURE("30"),
-    LARGE_MESSAGE_TIMEOUT("25"),
-    CLINICAL_SYSTEM_INTEGRATION_FAILURE("11"),
-    EHR_EXTRACT_CANNOT_BE_PROCESSED("21"),
-    UNEXPECTED_CONDITION("99"),
-    ABA_EHR_EXTRACT_REJECTED_WRONG_PATIENT("17"),
-    ABA_EHR_EXTRACT_SUPPRESSED("15"),
-    PATIENT_NOT_AT_SURGERY("06"),
-    NON_ABA_EHR_EXTRACT_REJECTED_WRONG_PATIENT("28");
+    LARGE_MESSAGE_REASSEMBLY_FAILURE(
+        "29", "Large Message Re-assembly failure"),
+    LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED(
+        "31", "The overall EHR Extract has been rejected because one or more attachments via Large Messages were not received."),
+    LARGE_MESSAGE_GENERAL_FAILURE(
+        "30", "Large Message general failure"),
+    LARGE_MESSAGE_TIMEOUT(
+        "25", "Large messages rejected due to timeout duration reached of overall transfer"),
+    CLINICAL_SYSTEM_INTEGRATION_FAILURE(
+        "11", "Failed to successfully integrate EHR Extract."),
+    EHR_EXTRACT_CANNOT_BE_PROCESSED(
+        "21", "EHR Extract message not well-formed or not able to be processed"),
+    UNEXPECTED_CONDITION(
+        "99", "Unexpected condition."),
+    ABA_EHR_EXTRACT_REJECTED_WRONG_PATIENT(
+        "17", "A-B-A EHR Extract Received and rejected due to wrong record or wrong patient"),
+    ABA_EHR_EXTRACT_SUPPRESSED(
+        "15", "A-B-A EHR Extract Received and Stored As Suppressed Record"),
+    PATIENT_NOT_AT_SURGERY(
+        "06", "Patient not at surgery."),
+    NON_ABA_EHR_EXTRACT_REJECTED_WRONG_PATIENT(
+        "28", "Non A-B-A EHR Extract Received and rejected due to wrong record or wrong patient");
 
-    @Getter
     private final String code;
+
+    private final String responseText;
+
+    NACKReason(String code, String responseText) {
+        this.code = code;
+        this.responseText = responseText;
+    }
 
     public MigrationStatus getMigrationStatus() {
         return switch (this) {


### PR DESCRIPTION

## What

Add `responseText` to enum `NACKReason` to be used when populating the NACK response.

## Why

As we now require the displayName to populated when providing a NACK response, we need to be able to provide responseText along with the code.  These values were populated from the details provided in the "NPFIT-PC-BLD-0083 GP2GP Response Codes" PDF.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation