### PR TITLE
Refactor: Replace NACKMessageData.nackCode String with NACKReason enum

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/model/NACKMessageData.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/model/NACKMessageData.java
@@ -13,7 +13,7 @@ public class NACKMessageData {
     private String conversationId;
 
     @NonNull
-    private String nackCode;
+    private NACKReason nackReason;
 
     @NonNull
     private String toOdsCode;

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/ApplicationAcknowledgementMessageService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/ApplicationAcknowledgementMessageService.java
@@ -38,7 +38,7 @@ public class ApplicationAcknowledgementMessageService {
             .toAsid(messageData.getToAsid())
             .fromAsid(messageData.getFromAsid())
             .messageRef(messageData.getMessageRef())
-            .nackCode(messageData.getNackCode())
+            .nackCode(messageData.getNackReason().getCode())
             .build();
 
         return fillTemplate(NACK_MESSAGE_TEMPLATE, params);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/NackAckPreparationService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/NackAckPreparationService.java
@@ -95,11 +95,10 @@ public class NackAckPreparationService implements NackAckPrepInterface {
         String messageRef = XmlParseUtilService.parseMessageRef(payload);
         String toAsid = XmlParseUtilService.parseToAsid(payload);
         String fromAsid = XmlParseUtilService.parseFromAsid(payload);
-        String nackCode = reason.getCode();
 
         return NACKMessageData.builder()
                 .conversationId(conversationId)
-                .nackCode(nackCode)
+                .nackReason(reason)
                 .toOdsCode(toOdsCode)
                 .messageRef(messageRef)
                 .toAsid(toAsid)
@@ -114,11 +113,10 @@ public class NackAckPreparationService implements NackAckPrepInterface {
         String messageRef = XmlParseUtilService.parseMessageRef(payload);
         String toAsid = XmlParseUtilService.parseToAsid(payload);
         String fromAsid = XmlParseUtilService.parseFromAsid(payload);
-        String nackCode = reason.getCode();
 
         return NACKMessageData.builder()
                 .conversationId(conversationId)
-                .nackCode(nackCode)
+                .nackReason(reason)
                 .toOdsCode(toOdsCode)
                 .messageRef(messageRef)
                 .toAsid(toAsid)

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandler.java
@@ -490,7 +490,7 @@ public class COPCMessageHandler {
 
         NACKMessageData messageData = NACKMessageData
             .builder()
-            .nackCode(reason.getCode())
+            .nackReason(reason)
             .fromAsid(outboundMessageUtil.parseFromAsid(ehrExtract))
             .toAsid(outboundMessageUtil.parseToAsid(ehrExtract))
             .toOdsCode(outboundMessageUtil.parseToOdsCode(ehrExtract))

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/scheduled/EHRTimeoutHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/scheduled/EHRTimeoutHandler.java
@@ -184,7 +184,7 @@ public class EHRTimeoutHandler {
 
         NACKMessageData messageData = NACKMessageData
             .builder()
-            .nackCode(reason.getCode())
+            .nackReason(reason)
             .fromAsid(outboundMessageUtil.parseFromAsid(payload))
             .toAsid(outboundMessageUtil.parseToAsid(payload))
             .toOdsCode(outboundMessageUtil.parseToOdsCode(payload))

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/ApplicationAcknowledgementMessageServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/ApplicationAcknowledgementMessageServiceTest.java
@@ -28,6 +28,7 @@ import org.xml.sax.SAXException;
 
 import uk.nhs.adaptors.common.util.DateUtils;
 import uk.nhs.adaptors.pss.translator.model.NACKMessageData;
+import uk.nhs.adaptors.pss.translator.model.NACKReason;
 
 @ExtendWith(MockitoExtension.class)
 public class ApplicationAcknowledgementMessageServiceTest {
@@ -38,7 +39,6 @@ public class ApplicationAcknowledgementMessageServiceTest {
     private static final String TEST_TO_ASID = "TEST_TO_ASID";
     private static final String TEST_TO_ODS = "TEST_TO_ODS";
     private static final String TEST_CONVERSATION_ID = "abcd12345";
-    private static final String NACK_CODE = "TEST_NACK_CODE";
 
     @Mock
     private DateUtils dateUtils;
@@ -56,7 +56,7 @@ public class ApplicationAcknowledgementMessageServiceTest {
         messageData = NACKMessageData.builder()
             .conversationId(TEST_CONVERSATION_ID)
             .toOdsCode(TEST_TO_ODS)
-            .nackCode(NACK_CODE)
+            .nackReason(NACKReason.LARGE_MESSAGE_TIMEOUT)
             .messageRef(MESSAGE_REF)
             .fromAsid(TEST_FROM_ASID)
             .toAsid(TEST_TO_ASID)
@@ -67,7 +67,7 @@ public class ApplicationAcknowledgementMessageServiceTest {
     public void When_BuildNackMessage_WithValidTestData_Expect_NackCodeIsSetCorrectly() {
         String nackMessage = messageService.buildNackMessage(messageData, MESSAGE_ID);
 
-        assertTrue(nackMessage.contains(NACK_CODE));
+        assertTrue(nackMessage.contains(NACKReason.LARGE_MESSAGE_TIMEOUT.getCode()));
     }
 
     @Test

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/NackAckPreparationServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/NackAckPreparationServiceTest.java
@@ -51,7 +51,6 @@ class NackAckPreparationServiceTest {
     private static final String TEST_MESSAGE_REF = "31FA3430-6E88-11EA-9384-E83935108FD5";
     private static final String TEST_TO_ASID = "200000000149";
     private static final String TEST_FROM_ASID = "200000001161";
-    private static final String TEST_NACK_CODE = "30";
 
     @Mock
     private MigrationStatusLogService migrationStatusLogService;
@@ -96,7 +95,7 @@ class NackAckPreparationServiceTest {
     public void When_SendNackMessageRCMR_WithValidParameters_Expect_ShouldParseMessageDataCorrectly() throws JAXBException {
 
         NACKMessageData expectedMessageData = NACKMessageData.builder()
-                .nackCode(TEST_NACK_CODE)
+                .nackReason(NACKReason.LARGE_MESSAGE_GENERAL_FAILURE)
                 .toOdsCode(TEST_TO_ODS)
                 .toAsid(TEST_TO_ASID)
                 .fromAsid(TEST_FROM_ASID)
@@ -127,7 +126,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals("29", ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(NACKReason.LARGE_MESSAGE_REASSEMBLY_FAILURE, ackMessageDataCaptor.getValue().getNackReason());
     }
 
     @Test
@@ -141,7 +140,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals("31", ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(NACKReason.LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED, ackMessageDataCaptor.getValue().getNackReason());
     }
 
     @Test
@@ -155,7 +154,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals(LARGE_MESSAGE_GENERAL_FAILURE.getCode(), ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(LARGE_MESSAGE_GENERAL_FAILURE, ackMessageDataCaptor.getValue().getNackReason());
     }
 
     @Test
@@ -169,7 +168,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals(LARGE_MESSAGE_TIMEOUT.getCode(), ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(LARGE_MESSAGE_TIMEOUT, ackMessageDataCaptor.getValue().getNackReason());
     }
 
     @Test
@@ -183,7 +182,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals(CLINICAL_SYSTEM_INTEGRATION_FAILURE.getCode(), ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(CLINICAL_SYSTEM_INTEGRATION_FAILURE, ackMessageDataCaptor.getValue().getNackReason());
     }
 
     @Test
@@ -197,7 +196,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals(EHR_EXTRACT_CANNOT_BE_PROCESSED.getCode(), ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(EHR_EXTRACT_CANNOT_BE_PROCESSED, ackMessageDataCaptor.getValue().getNackReason());
     }
 
     @Test
@@ -211,7 +210,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals(UNEXPECTED_CONDITION.getCode(), ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(UNEXPECTED_CONDITION, ackMessageDataCaptor.getValue().getNackReason());
     }
 
     @Test
@@ -258,7 +257,7 @@ class NackAckPreparationServiceTest {
     public void When_SendNackMessageCOPC_WithValidParameters_Expect_ShouldParseMessageDataCorrectly() throws JAXBException {
 
         NACKMessageData expectedMessageData = NACKMessageData.builder()
-                .nackCode(TEST_NACK_CODE)
+                .nackReason(NACKReason.LARGE_MESSAGE_GENERAL_FAILURE)
                 .toOdsCode(TEST_TO_ODS)
                 .toAsid(TEST_TO_ASID)
                 .fromAsid(TEST_FROM_ASID)
@@ -289,7 +288,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals(LARGE_MESSAGE_REASSEMBLY_FAILURE.getCode(), ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(LARGE_MESSAGE_REASSEMBLY_FAILURE, ackMessageDataCaptor.getValue().getNackReason());
     }
 
     @Test
@@ -303,7 +302,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals(LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getCode(), ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED, ackMessageDataCaptor.getValue().getNackReason());
     }
 
     @Test
@@ -317,7 +316,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals(LARGE_MESSAGE_GENERAL_FAILURE.getCode(), ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(LARGE_MESSAGE_GENERAL_FAILURE, ackMessageDataCaptor.getValue().getNackReason());
     }
 
     @Test
@@ -331,7 +330,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals(LARGE_MESSAGE_TIMEOUT.getCode(), ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(LARGE_MESSAGE_TIMEOUT, ackMessageDataCaptor.getValue().getNackReason());
     }
 
     @Test
@@ -345,7 +344,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals(CLINICAL_SYSTEM_INTEGRATION_FAILURE.getCode(), ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(CLINICAL_SYSTEM_INTEGRATION_FAILURE, ackMessageDataCaptor.getValue().getNackReason());
     }
 
     @Test
@@ -359,7 +358,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals(EHR_EXTRACT_CANNOT_BE_PROCESSED.getCode(), ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(EHR_EXTRACT_CANNOT_BE_PROCESSED, ackMessageDataCaptor.getValue().getNackReason());
     }
 
     @Test
@@ -373,7 +372,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals(UNEXPECTED_CONDITION.getCode(), ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(UNEXPECTED_CONDITION, ackMessageDataCaptor.getValue().getNackReason());
     }
 
     @Test

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandlerTest.java
@@ -1085,7 +1085,7 @@ class COPCMessageHandlerTest {
                 .sendNackMessage(eq(LARGE_MESSAGE_GENERAL_FAILURE), any(COPCIN000001UK01Message.class), eq(CONVERSATION_ID));
 
             verify(sendNACKMessageHandler).prepareAndSendMessage(nackMessageDataCaptor.capture());
-            assertThat(nackMessageDataCaptor.getValue().getNackCode()).isEqualTo(UNEXPECTED_CONDITION.getCode());
+            assertThat(nackMessageDataCaptor.getValue().getNackReason()).isEqualTo(UNEXPECTED_CONDITION);
 
         } finally {
             mockedXmlUnmarshall.close();
@@ -1119,7 +1119,7 @@ class COPCMessageHandlerTest {
                 .sendNackMessage(LARGE_MESSAGE_GENERAL_FAILURE, mockCOPCMessage, CONVERSATION_ID);
 
             verify(sendNACKMessageHandler).prepareAndSendMessage(nackMessageDataCaptor.capture());
-            assertThat(nackMessageDataCaptor.getValue().getNackCode()).isEqualTo(UNEXPECTED_CONDITION.getCode());
+            assertThat(nackMessageDataCaptor.getValue().getNackReason()).isEqualTo(UNEXPECTED_CONDITION);
 
         } finally {
             mockedXmlUnmarshall.close();
@@ -1164,7 +1164,7 @@ class COPCMessageHandlerTest {
                 .sendNackMessage(LARGE_MESSAGE_GENERAL_FAILURE, mockCOPCMessage, CONVERSATION_ID);
 
             verify(sendNACKMessageHandler).prepareAndSendMessage(nackMessageDataCaptor.capture());
-            assertThat(nackMessageDataCaptor.getValue().getNackCode()).isEqualTo(UNEXPECTED_CONDITION.getCode());
+            assertThat(nackMessageDataCaptor.getValue().getNackReason()).isEqualTo(UNEXPECTED_CONDITION);
 
         } finally {
             mockedXmlUnmarshall.close();
@@ -1201,7 +1201,7 @@ class COPCMessageHandlerTest {
                 .sendNackMessage(LARGE_MESSAGE_GENERAL_FAILURE, mockCOPCMessage, CONVERSATION_ID);
 
             verify(sendNACKMessageHandler).prepareAndSendMessage(nackMessageDataCaptor.capture());
-            assertThat(nackMessageDataCaptor.getValue().getNackCode()).isEqualTo(UNEXPECTED_CONDITION.getCode());
+            assertThat(nackMessageDataCaptor.getValue().getNackReason()).isEqualTo(UNEXPECTED_CONDITION);
 
         } finally {
             mockedXmlUnmarshall.close();
@@ -1237,7 +1237,7 @@ class COPCMessageHandlerTest {
                 .sendNackMessage(LARGE_MESSAGE_GENERAL_FAILURE, mockCOPCMessage, CONVERSATION_ID);
 
             verify(sendNACKMessageHandler).prepareAndSendMessage(nackMessageDataCaptor.capture());
-            assertEquals(LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getCode(), nackMessageDataCaptor.getValue().getNackCode());
+            assertEquals(LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED, nackMessageDataCaptor.getValue().getNackReason());
 
             verify(migrationStatusLogService, times(1))
                 .addMigrationStatusLog(LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getMigrationStatus(),

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendNACKMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendNACKMessageHandlerTest.java
@@ -28,6 +28,7 @@ import uk.nhs.adaptors.pss.translator.exception.MhsServerErrorException;
 import uk.nhs.adaptors.pss.translator.mhs.MhsRequestBuilder;
 import uk.nhs.adaptors.pss.translator.mhs.model.OutboundMessage;
 import uk.nhs.adaptors.pss.translator.model.NACKMessageData;
+import uk.nhs.adaptors.pss.translator.model.NACKReason;
 import uk.nhs.adaptors.pss.translator.service.ApplicationAcknowledgementMessageService;
 import uk.nhs.adaptors.pss.translator.service.IdGeneratorService;
 import uk.nhs.adaptors.pss.translator.service.MhsClientService;
@@ -40,7 +41,6 @@ public class SendNACKMessageHandlerTest {
     private static final String TEST_TO_ODS = "1234";
     private static final String TEST_TO_ASID = "5678";
     private static final String TEST_FROM_ASID = "98765";
-    private static final String TEST_NACK_CODE = "30";
     private static final String TEST_MESSAGE_ID = "test-message-id";
 
     @Mock
@@ -70,7 +70,7 @@ public class SendNACKMessageHandlerTest {
             .toOdsCode(TEST_TO_ODS)
             .toAsid(TEST_TO_ASID)
             .fromAsid(TEST_FROM_ASID)
-            .nackCode(TEST_NACK_CODE)
+            .nackReason(NACKReason.LARGE_MESSAGE_GENERAL_FAILURE)
             .build();
 
         when(idGeneratorService.generateUuid()).thenReturn(TEST_MESSAGE_ID);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/scheduled/EHRTimeoutHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/scheduled/EHRTimeoutHandlerTest.java
@@ -94,7 +94,6 @@ public class EHRTimeoutHandlerTest {
     private static final String EBXML_STRING = "test ebXML";
     private static final String EBXML_STRING_TWO = "test ebXML 2";
     private static final String UNEXPECTED_CONDITION_CODE = "99";
-    private static final String ATTACHMENTS_NOT_RECEIVED_CODE = "31";
 
     @Captor
     private ArgumentCaptor<NACKMessageData> nackMessageData;
@@ -186,7 +185,7 @@ public class EHRTimeoutHandlerTest {
         callCheckForTimeoutsWithOneRequest(EHR_EXTRACT_TRANSLATED, TEN_DAYS_AGO, 0, conversationId);
         verify(sendNACKMessageHandler, times(1)).prepareAndSendMessage(nackMessageData.capture());
 
-        assertThat(nackMessageData.getValue().getNackCode()).isEqualTo(UNEXPECTED_CONDITION_CODE);
+        assertThat(nackMessageData.getValue().getNackReason()).isEqualTo(UNEXPECTED_CONDITION);
     }
 
     @ParameterizedTest
@@ -196,7 +195,7 @@ public class EHRTimeoutHandlerTest {
         callCheckForTimeoutsWithOneRequest(migrationStatus, TEN_DAYS_AGO, 0, conversationId);
         verify(sendNACKMessageHandler, times(1)).prepareAndSendMessage(nackMessageData.capture());
 
-        assertThat(nackMessageData.getValue().getNackCode()).isEqualTo(ATTACHMENTS_NOT_RECEIVED_CODE);
+        assertThat(nackMessageData.getValue().getNackReason()).isEqualTo(LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Why

Will allow us to get both the code and the textual "Response text" from the enum when generating the XML.

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation