### PR TITLE
NIAD-3260: When sending a NACK to the sending system, also include the responseText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+* When sending a negative acknowledgement to the sending system in the event of a failure, include the textual
+  description of the reason, e.g. "EHR Extract message not well-formed or not able to be processed".
+  This behaviour while not required by the spec, has been implemented by other GP2GP systems, and is expected to be
+  provided by one implementation.
+
 ## [3.0.8] - 2024-11-22
 
 ### Fixed

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/FailedProcessHandingIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/FailedProcessHandingIT.java
@@ -204,7 +204,7 @@ public class FailedProcessHandingIT extends BaseEhrHandler {
             && mostRecentRequest.getBody()
                 .contains("<acknowledgement typeCode=\\\"AE\\\">")
             && mostRecentRequest.getBody()
-                .contains("<code code=\\\"" + code + "\\\" codeSystem=\\\"2.16.840.1.113883.2.1.3.2.4.17.101\\\">");
+                .contains("<code code=\\\"" + code + "\\\" codeSystem=\\\"2.16.840.1.113883.2.1.3.2.4.17.101\\\"");
     }
 
     private List<Request> getMhsRequestsForConversation() {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/ApplicationAcknowledgementMessageService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/ApplicationAcknowledgementMessageService.java
@@ -38,7 +38,7 @@ public class ApplicationAcknowledgementMessageService {
             .toAsid(messageData.getToAsid())
             .fromAsid(messageData.getFromAsid())
             .messageRef(messageData.getMessageRef())
-            .nackCode(messageData.getNackReason().getCode())
+            .nackReason(messageData.getNackReason())
             .build();
 
         return fillTemplate(NACK_MESSAGE_TEMPLATE, params);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/template/parameter/ApplicationAcknowledgmentParams.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/template/parameter/ApplicationAcknowledgmentParams.java
@@ -2,13 +2,14 @@ package uk.nhs.adaptors.pss.translator.util.template.parameter;
 
 import lombok.Builder;
 import lombok.Getter;
+import uk.nhs.adaptors.pss.translator.model.NACKReason;
 
 @Getter
 @Builder
 public class ApplicationAcknowledgmentParams {
     private String messageId;
     private String creationTime;
-    private String nackCode;
+    private NACKReason nackReason;
     private String messageRef;
     private String toAsid;
     private String fromAsid;

--- a/gp2gp-translator/src/main/resources/templates/applicationAcknowledgementTemplate.mustache
+++ b/gp2gp-translator/src/main/resources/templates/applicationAcknowledgementTemplate.mustache
@@ -7,7 +7,7 @@
     <processingCode code="P"/>
     <processingModeCode code="T"/>
     <acceptAckCode code="NE"/>
-    <acknowledgement {{#nackCode}}typeCode="AE"{{/nackCode}}{{^nackCode}}typeCode="AA"{{/nackCode}}>
+    <acknowledgement {{#nackReason}}typeCode="AE"{{/nackReason}}{{^nackReason}}typeCode="AA"{{/nackReason}}>
         <messageRef>
             <id root="{{messageRef}}"/>
         </messageRef>
@@ -30,16 +30,16 @@
                 </agentSystemSDS>
             </AgentSystemSDS>
         </author1>
-        {{#nackCode}}
+        {{#nackReason}}
         <reason typeCode="RSON">
             <justifyingDetectedIssueEvent classCode="ALRT" moodCode="EVN">
-                <code code="{{nackCode}}" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.101">
+                <code code="{{nackReason.code}}" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.101" displayName="{{nackReason.responseText}}">
                     <qualifier>
                         <value code="ER" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.104"/>
                     </qualifier>
                 </code>
             </justifyingDetectedIssueEvent>
         </reason>
-        {{/nackCode}}
+        {{/nackReason}}
     </ControlActEvent>
 </MCCI_IN010000UK13>

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/ApplicationAcknowledgementMessageServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/ApplicationAcknowledgementMessageServiceTest.java
@@ -1,8 +1,7 @@
 package uk.nhs.adaptors.pss.translator.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.when;
 
 import static uk.nhs.adaptors.pss.translator.util.DateFormatUtil.toHl7Format;
@@ -67,35 +66,35 @@ public class ApplicationAcknowledgementMessageServiceTest {
     public void When_BuildNackMessage_WithValidTestData_Expect_NackCodeIsSetCorrectly() {
         String nackMessage = messageService.buildNackMessage(messageData, MESSAGE_ID);
 
-        assertTrue(nackMessage.contains(NACKReason.LARGE_MESSAGE_TIMEOUT.getCode()));
+        assertThat(nackMessage).contains(NACKReason.LARGE_MESSAGE_TIMEOUT.getCode());
     }
 
     @Test
     public void When_BuildNackMessage_WithValidTestData_Expect_MessageIdIsSetCorrectly() {
         String nackMessage = messageService.buildNackMessage(messageData, MESSAGE_ID);
 
-        assertTrue(nackMessage.contains(MESSAGE_ID));
+        assertThat(nackMessage).contains(MESSAGE_ID);
     }
 
     @Test
     public void When_BuildNackMessage_WithValidTestData_Expect_MessageRefIsSetCorrectly() {
         String nackMessage = messageService.buildNackMessage(messageData, MESSAGE_ID);
 
-        assertTrue(nackMessage.contains(MESSAGE_REF));
+        assertThat(nackMessage).contains(MESSAGE_REF);
     }
 
     @Test
     public void When_BuildNackMessage_WithValidTestData_Expect_ToAsidIsSetCorrectly() {
         String nackMessage = messageService.buildNackMessage(messageData, MESSAGE_ID);
 
-        assertTrue(nackMessage.contains(TEST_TO_ASID));
+        assertThat(nackMessage).contains(TEST_TO_ASID);
     }
 
     @Test
     public void When_NackMessage_WithTestData_Expect_FromAsidIsSetCorrectly() {
         String nackMessage = messageService.buildNackMessage(messageData, MESSAGE_ID);
 
-        assertTrue(nackMessage.contains(TEST_FROM_ASID));
+        assertThat(nackMessage).contains(TEST_FROM_ASID);
     }
 
     @Test
@@ -105,15 +104,17 @@ public class ApplicationAcknowledgementMessageServiceTest {
 
         String nackMessage = messageService.buildNackMessage(messageData, MESSAGE_ID);
 
-        assertTrue(nackMessage.contains(toHl7Format(instant)));
+        assertThat(nackMessage).contains(toHl7Format(instant));
     }
 
     @Test
     public void When_NackMessage_WithNackCodePresent_Expect_TypeCodeSetCorrectly() {
         String nackMessage = messageService.buildNackMessage(messageData, MESSAGE_ID);
 
-        assertTrue(nackMessage.contains("typeCode=\"AE\""));
-        assertFalse(nackMessage.contains("typeCode=\"AA\""));
+        assertAll(
+            () -> assertThat(nackMessage).contains("typeCode=\"AE\""),
+            () -> assertThat(nackMessage).doesNotContain("typeCode=\"AA\"")
+        );
     }
 
     @Test
@@ -126,7 +127,7 @@ public class ApplicationAcknowledgementMessageServiceTest {
         Document messageXml = db.parse(new InputSource(new StringReader(nackMessage)));
         NodeList nodes = messageXml.getElementsByTagName("reason");
 
-        assertTrue(nodes.getLength() > 0);
+        assertThat(nodes.getLength()).isEqualTo(1);
     }
 
     @Test
@@ -140,6 +141,6 @@ public class ApplicationAcknowledgementMessageServiceTest {
         NodeList nodes = messageXml.getElementsByTagName("reason");
         String reasonAttribute = nodes.item(0).getAttributes().item(0).toString();
 
-        assertEquals("typeCode=\"RSON\"", reasonAttribute);
+        assertThat(reasonAttribute).isEqualTo("typeCode=\"RSON\"");
     }
 }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/ApplicationAcknowledgementMessageServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/ApplicationAcknowledgementMessageServiceTest.java
@@ -63,10 +63,13 @@ public class ApplicationAcknowledgementMessageServiceTest {
     }
 
     @Test
-    public void When_BuildNackMessage_WithValidTestData_Expect_NackCodeIsSetCorrectly() {
+    public void When_BuildNackMessage_WithValidTestData_Expect_NackCodeAndResponseTextAreOutput() {
         String nackMessage = messageService.buildNackMessage(messageData, MESSAGE_ID);
 
-        assertThat(nackMessage).contains(NACKReason.LARGE_MESSAGE_TIMEOUT.getCode());
+        assertAll(
+            () -> assertThat(nackMessage).contains("code=\"" + NACKReason.LARGE_MESSAGE_TIMEOUT.getCode() + "\""),
+            () -> assertThat(nackMessage).contains("displayName=\"" + NACKReason.LARGE_MESSAGE_TIMEOUT.getResponseText() + "\"")
+        );
     }
 
     @Test


### PR DESCRIPTION
## Why

It appears that other GP2GP implementations send the NACK response text as part of the coded response.

This change brings us in line with these.

Furthermore, one implementation claims that they require this field to be populated otherwise they will error.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation