### PR TITLE
Refactor `NackAckPreparationsServiceTest` to reduce code duplication

### DIFF
--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/NackAckPreparationServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/NackAckPreparationServiceTest.java
@@ -65,17 +65,21 @@ class NackAckPreparationServiceTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void When_SendNackMessageRCMR_Expect_ShouldUpdateLogAndReturnPrepareAndSendMessageResult(boolean expectedResult)
+    public void When_SendNackMessageRCMR_Expect_ShouldUpdateLogAndReturnPrepareAndSendMessageResult(boolean ableToSendMessage)
         throws JAXBException {
 
         RCMRIN030000UKMessage payload = unmarshallString(readInboundMessagePayloadFromFile(), RCMRIN030000UKMessage.class);
-        when(sendNACKMessageHandler.prepareAndSendMessage(any(NACKMessageData.class))).thenReturn(expectedResult);
+        when(sendNACKMessageHandler.prepareAndSendMessage(any(NACKMessageData.class))).thenReturn(ableToSendMessage);
 
-        var actualResult = nackAckPreparationService.sendNackMessage(NACKReason.LARGE_MESSAGE_GENERAL_FAILURE, payload, CONVERSATION_ID);
+        var hasMessageBeenSent = nackAckPreparationService.sendNackMessage(
+            NACKReason.LARGE_MESSAGE_GENERAL_FAILURE,
+            payload,
+            CONVERSATION_ID
+        );
 
         verify(migrationStatusLogService)
             .addMigrationStatusLog(ERROR_LRG_MSG_GENERAL_FAILURE, CONVERSATION_ID, null, LARGE_MESSAGE_GENERAL_FAILURE.getCode());
-        assertThat(actualResult).isEqualTo(expectedResult);
+        assertThat(hasMessageBeenSent).isEqualTo(ableToSendMessage);
     }
 
     @ParameterizedTest
@@ -98,7 +102,8 @@ class NackAckPreparationServiceTest {
         nackAckPreparationService.sendNackMessage(
                 nackReason,
                 payload,
-                CONVERSATION_ID);
+                CONVERSATION_ID
+        );
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
         assertEquals(expectedMessageData, ackMessageDataCaptor.getValue());
@@ -123,17 +128,21 @@ class NackAckPreparationServiceTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void When_SendNackMessageCOPC_Expect_ShouldUpdateLogAndReturnPrepareAndSendMessageResult(boolean expectedResult)
+    public void When_SendNackMessageCOPC_Expect_ShouldUpdateLogAndReturnPrepareAndSendMessageResult(boolean ableToSendMessage)
         throws JAXBException {
 
         var payload = unmarshallString(readSubsequentInboundMessagePayloadFromFile(), COPCIN000001UK01Message.class);
-        when(sendNACKMessageHandler.prepareAndSendMessage(any(NACKMessageData.class))).thenReturn(expectedResult);
+        when(sendNACKMessageHandler.prepareAndSendMessage(any(NACKMessageData.class))).thenReturn(ableToSendMessage);
 
-        var actualResult = nackAckPreparationService.sendNackMessage(NACKReason.LARGE_MESSAGE_GENERAL_FAILURE, payload, CONVERSATION_ID);
+        var hasMessageBeenSent = nackAckPreparationService.sendNackMessage(
+            NACKReason.LARGE_MESSAGE_GENERAL_FAILURE,
+            payload,
+            CONVERSATION_ID
+        );
 
         verify(migrationStatusLogService)
             .addMigrationStatusLog(ERROR_LRG_MSG_GENERAL_FAILURE, CONVERSATION_ID, null, LARGE_MESSAGE_GENERAL_FAILURE.getCode());
-        assertThat(actualResult).isEqualTo(expectedResult);
+        assertThat(hasMessageBeenSent).isEqualTo(ableToSendMessage);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## What

* Refactor `NackAckPreparationsServiceTest` to reduce duplicated code and consolidate into parameterised tests where suitable.

## Why

There were a lot of test each testing permutations of an `enum` for both the RCMR and COPC set of tests. These were unnecessary and could be consolidated into parameterised tests.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation