### PR TITLE
Clear ApplicationContext before each ServiceFailureIT test

### DIFF
--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/amqp/ServiceFailureIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/amqp/ServiceFailureIT.java
@@ -64,7 +64,7 @@ import jakarta.jms.Message;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ExtendWith({SpringExtension.class, MockitoExtension.class})
-@DirtiesContext
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureMockMvc
 public class ServiceFailureIT extends BaseEhrHandler {
 


### PR DESCRIPTION
## Why

It appears that the SpyBeans are causing issues between tests. One spy can interfere with a subsequent test.

Clearing the ApplicationContext between each test seems to fix this.

Downside of this is that the tests are a bit slower, but given that the tests already take 5 minutes that isn't a noticable change.

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation