### PR TITLE
Remove call to deprecated HttpHeaders.writableHttpHeaders method

### DIFF
--- a/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/controller/handler/OperationOutcomeExceptionHandler.java
+++ b/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/controller/handler/OperationOutcomeExceptionHandler.java
@@ -143,7 +143,7 @@ public class OperationOutcomeExceptionHandler extends ResponseEntityExceptionHan
     }
 
     private ResponseEntity<Object> errorResponse(HttpHeaders headers, HttpStatusCode status, OperationOutcome operationOutcome) {
-        headers = HttpHeaders.writableHttpHeaders(headers);
+        headers = new HttpHeaders(headers);
         headers.put(CONTENT_TYPE, singletonList(APPLICATION_FHIR_JSON_VALUE));
         String content = fhirParser.encodeToJson(operationOutcome);
         return new ResponseEntity<>(content, headers, status);


### PR DESCRIPTION
## Why

Since upgrading to Spring Framework 6.2, this method has been deprecated, and it's now producing a warning within the logs.

Use replacement method instead

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation