### PR TITLE
NIAD-3269: Fixing getMigrationRequestId throwing exception

### DIFF
--- a/db-connector/src/main/java/uk/nhs/adaptors/connector/service/MigrationStatusLogService.java
+++ b/db-connector/src/main/java/uk/nhs/adaptors/connector/service/MigrationStatusLogService.java
@@ -12,6 +12,7 @@ import uk.nhs.adaptors.common.enums.MigrationStatus;
 import uk.nhs.adaptors.connector.model.MigrationStatusLog;
 
 import java.util.List;
+import java.util.Locale;
 
 @Slf4j
 @Service
@@ -24,7 +25,7 @@ public class MigrationStatusLogService {
 
     public void addMigrationStatusLog(MigrationStatus migrationStatus, String conversationId, String messageId, String gp2gpErrorCode) {
 
-        int migrationRequestId = patientMigrationRequestDao.getMigrationRequestId(conversationId);
+        int migrationRequestId = patientMigrationRequestDao.getMigrationRequestId(conversationId.toUpperCase(Locale.ROOT));
         migrationStatusLogDao.addMigrationStatusLog(
             migrationStatus,
             dateUtils.getCurrentOffsetDateTime(),

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/amqp/ServiceFailureIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/amqp/ServiceFailureIT.java
@@ -24,6 +24,7 @@ import static uk.nhs.adaptors.common.enums.QueueMessageType.TRANSFER_REQUEST;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Locale;
 
 import ca.uhn.fhir.parser.DataFormatException;
 import org.apache.qpid.jms.message.JmsTextMessage;
@@ -78,6 +79,7 @@ public class ServiceFailureIT extends BaseEhrHandler {
     public static final String JSON_LARGE_MESSAGE_SCENARIO_3_COPC_JSON = "/json/LargeMessage/Scenario_3/copc.json";
     public static final String JSON_LARGE_MESSAGE_EXPECTED_BUNDLE_SCENARIO_3_JSON = "/json/LargeMessage/expectedBundleScenario3.json";
     public static final int RECEIVE_TIMEOUT_LIMIT = 50;
+    private String conversationId;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -117,11 +119,12 @@ public class ServiceFailureIT extends BaseEhrHandler {
             "entry[*].resource.content[0].attachment.url",
             "entry[*].resource.description"
         ));
+        conversationId = generateConversationId().toUpperCase(Locale.ROOT);
     }
 
     @Test
     public void When_SendingInitialRequest_WithMhsOutboundServerError_Expect_MigrationLogHasRequestError() {
-        var conversationId = generateConversationId();
+
         var patientNhsNumber = generatePatientNhsNumber();
 
         doThrow(getInternalServerErrorException())
@@ -201,7 +204,7 @@ public class ServiceFailureIT extends BaseEhrHandler {
     @Test
     public void When_SendingInitialRequest_WithMhsWebClientRequestException_Expect_MigrationCompletesWhenMhsRecovers()
         throws JSONException {
-        var conversationId = generateConversationId();
+
         var patientNhsNumber = generatePatientNhsNumber();
 
         doThrow(WebClientRequestException.class)
@@ -298,7 +301,7 @@ public class ServiceFailureIT extends BaseEhrHandler {
 
     @Test
     public void When_SendingInitialRequest_WithDBConnectionException_Expect_MigrationCompletesWhenMhsRecovers() throws JSONException {
-        var conversationId = generateConversationId();
+
         var patientNhsNumber = generatePatientNhsNumber();
 
         doThrow(ConnectionException.class)

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/task/scheduled/EHRTimeoutHandlerIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/task/scheduled/EHRTimeoutHandlerIT.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.Locale;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -108,7 +109,7 @@ public class EHRTimeoutHandlerIT {
         String winningOdsCode = "A0378";
         String nhsNumber = "9446363101";
         String persistDuration = "PT4H";
-        String conversationId = UUID.randomUUID().toString();
+        String conversationId = UUID.randomUUID().toString().toUpperCase(Locale.ROOT);
         InboundMessage inboundMessage = createInboundMessage();
 
         when(sdsService.getPersistDurationFor(any(), any(), any())).thenReturn(Duration.parse(persistDuration));


### PR DESCRIPTION
## What

getMigrationRequestId method of PatientMigrationRequestDao class causes an exception

## Why

In the code, both lower and upper case variants of conversationId are used. Since the database is case-sensitive, this inconsistency leads to various issues and state mismatches caused by case sensitivity.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation