### PR TITLE
NIAD-3001: Conditions are mapped into relatedProblemHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+* the relatedProblemHeader extension is populated in the GP Connect Topic List when mapping an ehrComposition with a flat structure
+
 ## [3.0.9] - 2025-01-22 
 
 ### Fixed

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -1867,6 +1867,15 @@
       "meta": {
         "profile": [ "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1" ]
       },
+      "extension": [ {
+        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
+        "extension": [ {
+          "url": "target",
+          "valueReference": {
+            "reference": "Condition/31EA7C21-BE35-4837-91A5-D66D8C375338"
+          }
+        } ]
+      } ],
       "status": "current",
       "mode": "snapshot",
       "code": {
@@ -1903,6 +1912,15 @@
       "meta": {
         "profile": [ "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1" ]
       },
+      "extension": [ {
+        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
+        "extension": [ {
+          "url": "target",
+          "valueReference": {
+            "reference": "Condition/AF0A6931-7ACD-40D7-B3A8-6CF056099A72"
+          }
+        } ]
+      } ],
       "status": "current",
       "mode": "snapshot",
       "code": {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/EncounterMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/EncounterMapper.java
@@ -162,12 +162,11 @@ public class EncounterMapper {
     }
 
     private Set<String> splitAndExtractConditionIds(List<Reference> entryReferences) {
-        Set<String> conditionIds = entryReferences.stream()
+        return entryReferences.stream()
                                                   .map(reference -> reference.getReference().split("/"))
                                                   .filter(parts -> CONDITION.equals(parts[0]))
                                                   .map(parts -> parts[1])
                                                   .collect(Collectors.toSet());
-        return conditionIds;
     }
 
     private List<Extension> getRelatedProblemsForStructuredConsultation(RCMRMT030101UKCompoundStatement topicCompoundStatement,

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/EncounterMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/EncounterMapper.java
@@ -51,7 +51,6 @@ import uk.nhs.adaptors.pss.translator.service.ConfidentialityService;
 import uk.nhs.adaptors.pss.translator.util.DateFormatUtil;
 import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 import uk.nhs.adaptors.pss.translator.util.ResourceReferenceUtil;
-
 import static uk.nhs.adaptors.common.util.CodeableConceptUtils.createCodeableConcept;
 
 @Service
@@ -157,12 +156,18 @@ public class EncounterMapper {
 
     private List<Extension> getRelatedProblemsForFlatStructuredConsultation(List<Reference> entryReferences) {
 
-        Set conditionIds = entryReferences.stream().map(reference -> reference.getReference().split("/"))
-            .filter(parts -> CONDITION.equals(parts[0]))
-            .map(parts -> parts[1])
-            .collect(Collectors.toSet());
+        Set<String> conditionIds = splitAndExtractConditionIds(entryReferences);
 
         return buildRelatedProblemExtensionsForConditions(conditionIds);
+    }
+
+    private Set<String> splitAndExtractConditionIds(List<Reference> entryReferences) {
+        Set<String> conditionIds = entryReferences.stream()
+                                                  .map(reference -> reference.getReference().split("/"))
+                                                  .filter(parts -> CONDITION.equals(parts[0]))
+                                                  .map(parts -> parts[1])
+                                                  .collect(Collectors.toSet());
+        return conditionIds;
     }
 
     private List<Extension> getRelatedProblemsForStructuredConsultation(RCMRMT030101UKCompoundStatement topicCompoundStatement,

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/EncounterMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/EncounterMapperTest.java
@@ -598,13 +598,14 @@ public class EncounterMapperTest {
         when(consultationListMapper.mapToConsultation(any(RCMRMT030101UKEhrComposition.class), any(Encounter.class)))
             .thenReturn(getList());
         when(consultationListMapper.mapToTopic(any(ListResource.class), isNull())).thenReturn(getList());
+        String conditionTopicListEntry = "Condition/4971E81E-693C-11EE-9D98-00155D78C707";
         doAnswer(invocation -> {
             List<Reference> list = invocation.getArgument(1);
             list.add(new Reference("Observation/4971E81B-693C-11EE-9D98-00155D78C707"));
             list.add(new Reference("Condition/4971E81C-693C-11EE-9D98-00155D78C707"));
             list.add(new Reference("Observation/4971E81D-693C-11EE-9D98-00155D78C707"));
-            list.add(new Reference("Condition/4971E81E-693C-11EE-9D98-00155D78C707"));
-            list.add(new Reference("Condition/4971E81E-693C-11EE-9D98-00155D78C707"));
+            list.add(new Reference(conditionTopicListEntry));
+            list.add(new Reference(conditionTopicListEntry));
             return null;
         }).when(resourceReferenceUtil).extractChildReferencesFromEhrComposition(
             any(RCMRMT030101UKEhrComposition.class),
@@ -618,7 +619,9 @@ public class EncounterMapperTest {
         assertThat(mappedResources.get(TOPIC_KEY).size()).isOne();
         assertThat(mappedResources.get(TOPIC_KEY).getFirst().getExtension()).hasSize(2);
         assertEquals(RELATED_PROBLEM_EXT_URL, mappedResources.get(TOPIC_KEY).getFirst().getExtension().get(0).getUrl());
-        assertEquals(RELATED_PROBLEM_EXT_URL, mappedResources.get(TOPIC_KEY).getFirst().getExtension().get(1).getUrl());
+        assertEquals(conditionTopicListEntry,
+                     ((Reference) mappedResources.get(TOPIC_KEY).getFirst().getExtension().get(0).getExtension().getFirst()
+                         .getValue()).getReference());
     }
 
     @ParameterizedTest

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/EncounterMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/EncounterMapperTest.java
@@ -2,6 +2,7 @@ package uk.nhs.adaptors.pss.translator.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -616,6 +617,8 @@ public class EncounterMapperTest {
 
         assertThat(mappedResources.get(TOPIC_KEY).size()).isOne();
         assertThat(mappedResources.get(TOPIC_KEY).getFirst().getExtension()).hasSize(2);
+        assertEquals(RELATED_PROBLEM_EXT_URL, mappedResources.get(TOPIC_KEY).getFirst().getExtension().get(0).getUrl());
+        assertEquals(RELATED_PROBLEM_EXT_URL, mappedResources.get(TOPIC_KEY).getFirst().getExtension().get(1).getUrl());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## What

Conditions are mapped into relatedProblemHeader

## Why

When mapping an ehrComposition which contains a “flat” structure, i.e. no Topic, when the [GP Connect Topic List](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_list_consultation.html#list-topic) is generated then the “relatedProblemHeader” extension is populated.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation