### PR TITLE
Replace all usages of deprecated MockBean with MockitoBean

### DIFF
--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/E2EMappingIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/E2EMappingIT.java
@@ -16,9 +16,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -45,7 +45,7 @@ public class E2EMappingIT extends BaseEhrHandler {
     @Autowired
     private JmsTemplate mhsJmsTemplate;
 
-    @MockBean
+    @MockitoBean
     private IdGeneratorService idGeneratorService;
 
     @BeforeEach

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/EhrExtractHandlingIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/EhrExtractHandlingIT.java
@@ -22,9 +22,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -69,7 +69,7 @@ public class EhrExtractHandlingIT extends BaseEhrHandler  {
         "entry[504].resource.identifier[0].value"
     );
 
-    @MockBean
+    @MockitoBean
     private IdGeneratorService idGeneratorService;
 
     @Qualifier("jmsTemplateMhsQueue")

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/service/AcknowledgeRecordServiceIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/service/AcknowledgeRecordServiceIT.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.nhs.adaptors.common.enums.ConfirmationResponse;
 import uk.nhs.adaptors.common.model.AcknowledgeRecordMessage;
@@ -38,7 +38,7 @@ public class AcknowledgeRecordServiceIT {
     @Autowired
     private AcknowledgeRecordService acknowledgeRecordService;
 
-    @MockBean
+    @MockitoBean
     private NackAckPrepInterface nackAckPrepInterface;
 
     private static final String CONVERSATION_ID_VALUE = UUID.randomUUID().toString();

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/task/scheduled/EHRTimeoutHandlerIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/task/scheduled/EHRTimeoutHandlerIT.java
@@ -26,10 +26,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -62,10 +62,10 @@ public class EHRTimeoutHandlerIT {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean
+    @MockitoBean
     private SDSService sdsService;
 
-    @MockBean
+    @MockitoBean
     private SendNACKMessageHandler nackMessageHandler;
 
     @Test


### PR DESCRIPTION
## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation