### PR TITLE
Niad 3286 migration timeout override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+* Added migration timeout override option
+
 ## [3.0.11] - 2025-05-15
 
 ### Fixed

--- a/OPERATING.md
+++ b/OPERATING.md
@@ -65,7 +65,10 @@ updated is configurable via the environment variable `TIMEOUT_SDS_POLL_FREQUENCY
 
 The adaptor checks incomplete transfers periodically, at a default frequency of every six hours. However, this is configurable via the environment variable `TIMEOUT_CRON_TIME`.
 
-For more configuration see the [Migration timeout variables](#migration-timeout-variables) section.
+Should you wish to specify a maximum timeout period (in seconds), thus bypassing the above logic, you may specify the 
+value in the `migrationTimeoutOverride` environment variable.
+
+For more configuration options see the [Migration timeout variables](#migration-timeout-variables) section.
 
 ## Adaptor behavior during dependent component downtime
 
@@ -390,6 +393,7 @@ The following variables are used determine if a [migration has timed out](#timeo
     defined in terms of the number of times a migration has been identified by the timeout cron, default = `3`
   - `TIMEOUT_EHR_EXTRACT_WEIGHTING`: The weighting factor A, to account transmission delays and volume throughput times of the RCMR_IN030000UK06 message, default = `1`
   - `TIMEOUT_COPC_WEIGHTING`: The weighting factor B, to account transmission delays and volume throughput times of the COPC_IN000001UK01 message, default = `1`
+  - `TIMEOUT_MIGRATION_TIME_OUTOVERRIDE`: Number of seconds after which the timeout is triggered, overriding the standard timeout logic, default = `0` (meaning disabled) 
 
 [spring-cron-expression]: https://spring.io/blog/2020/11/10/new-in-spring-5-3-improved-cron-expressions
 [mhs-adaptor]: https://github.com/nhsconnect/integration-adaptor-mhs/

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/config/TimeoutProperties.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/config/TimeoutProperties.java
@@ -14,4 +14,5 @@ public class TimeoutProperties {
     private int ehrExtractWeighting;
     private int copcWeighting;
     private int sdsPollFrequency;
+    private long migrationTimeoutOverride;
 }

--- a/gp2gp-translator/src/main/resources/application.yml
+++ b/gp2gp-translator/src/main/resources/application.yml
@@ -60,5 +60,6 @@ timeout:
   copcWeighting: ${TIMEOUT_COPC_WEIGHTING:1}
   cronTime: ${TIMEOUT_CRON_TIME:0 0 */2 * * *}
   sdsPollFrequency: ${TIMEOUT_SDS_POLL_FREQUENCY:3}
+  migrationTimeoutOverride: 0
 
 

--- a/gp2gp-translator/src/main/resources/application.yml
+++ b/gp2gp-translator/src/main/resources/application.yml
@@ -60,6 +60,6 @@ timeout:
   copcWeighting: ${TIMEOUT_COPC_WEIGHTING:1}
   cronTime: ${TIMEOUT_CRON_TIME:0 0 */2 * * *}
   sdsPollFrequency: ${TIMEOUT_SDS_POLL_FREQUENCY:3}
-  migrationTimeoutOverride: 0
+  migrationTimeoutOverride: ${TIMEOUT_MIGRATION_TIME_OUTOVERRIDE:0}
 
 


### PR DESCRIPTION
## What

Added ability for an environment variable override to the migration timeout logic

## Why

The current timeout logic means a request with many COPC messages may take days/weeks before it times out if there is no response. See Medicus Slack Thread for more analysis of this issue. This impacts Medicus being able to request the patient again, as you cannot start a new request until the current request has completed or failed.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation