### PR TITLE
NIAD-3296: `Practitioner.name.family` cardinality has been relaxed to optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 * Added migration timeout override option
 
+### Changed
+
+* **[Breaking Change - GP Connect 1.6.2]** When an `agentPerson` is provided with either an empty or missing name `name`
+  element, this would previously result in a `resource[Practitioner]` with `name[0].family` set to `Unknown`.
+  This will no longer be set, but instead `resource[Practitioner].name[0].text` will now be populated with `Unknown`.
+* **[Breaking Change - GP Connect 1.6.2]** When an `agentPerson` is provided with either an empty or missing
+  `agentPerson / name / family` then this will result in a `resource[practitioner].name[0]` without `family`, `prefix`
+  or `given` populated.
+  The field `resource[practitioner].name[0].text` will instead now be populated with these values.
+
 ## [3.0.11] - 2025-05-15
 
 ### Fixed

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
@@ -117,28 +117,35 @@ public class AgentDirectoryMapper {
         var humanName = new HumanName().setUse(NameUse.OFFICIAL);
         nameList.add(humanName);
 
-        if (name == null) {
-            humanName.setFamily(UNKNOWN);
+        if (hasNoName(name)) {
+            humanName.setText(UNKNOWN);
             return nameList;
         }
 
-        humanName.setFamily(getPractitionerFamily(name.getFamily()));
+        if (StringUtils.isNotBlank(name.getFamily())) {
+            humanName.setFamily(name.getFamily());
 
-        var given = getPractitionerGiven(name.getGiven());
-        if (given != null) {
-            humanName.getGiven().add(given);
-        }
+            var given = getPractitionerGiven(name.getGiven());
+            if (given != null) {
+                humanName.getGiven().add(given);
+            }
 
-        var prefix = getPractitionerPrefix(name.getPrefix());
-        if (prefix != null) {
-            humanName.getPrefix().add(prefix);
+            var prefix = getPractitionerPrefix(name.getPrefix());
+            if (prefix != null) {
+                humanName.getPrefix().add(prefix);
+            }
+        } else {
+            String[] details = new String[] { name.getPrefix(), name.getGiven() };
+            var text = StringUtils.join(details, ' ');
+
+            humanName.setText(text);
         }
 
         return nameList;
     }
 
-    private String getPractitionerFamily(String family) {
-        return StringUtils.isNotEmpty(family) ? family : UNKNOWN;
+    private static boolean hasNoName(PN name) {
+        return name == null || (name.getFamily() == null && name.getGiven() == null && name.getPrefix() == null);
     }
 
     private StringType getPractitionerGiven(String given) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
@@ -113,39 +113,47 @@ public class AgentDirectoryMapper {
     }
 
     private List<HumanName> getPractitionerName(PN name) {
-        var nameList = new ArrayList<HumanName>();
         var humanName = new HumanName().setUse(NameUse.OFFICIAL);
-        nameList.add(humanName);
 
         if (hasNoName(name)) {
             humanName.setText(UNKNOWN);
-            return nameList;
+            return List.of(humanName);
         }
 
-        if (StringUtils.isNotBlank(name.getFamily())) {
-            humanName.setFamily(name.getFamily());
-
-            var given = getPractitionerGiven(name.getGiven());
-            if (given != null) {
-                humanName.getGiven().add(given);
-            }
-
-            var prefix = getPractitionerPrefix(name.getPrefix());
-            if (prefix != null) {
-                humanName.getPrefix().add(prefix);
-            }
-        } else {
-            String[] details = new String[] { name.getPrefix(), name.getGiven() };
-            var text = StringUtils.join(details, ' ');
-
+        if (hasNoFamilyName(name)) {
+            var text = StringUtils.join(new String[] { name.getPrefix(), name.getGiven() }, ' ');
             humanName.setText(text);
+            return List.of(humanName);
         }
 
-        return nameList;
+        setHumanNameValuesFromName(name, humanName);
+        return List.of(humanName);
+    }
+
+    private void setHumanNameValuesFromName(PN name, HumanName humanName) {
+        humanName.setFamily(name.getFamily());
+
+        var given = getPractitionerGiven(name.getGiven());
+        if (given != null) {
+            humanName.getGiven().add(given);
+        }
+
+        var prefix = getPractitionerPrefix(name.getPrefix());
+        if (prefix != null) {
+            humanName.getPrefix().add(prefix);
+        }
+    }
+
+    private static boolean hasNoFamilyName(PN name) {
+        return name.getFamily() == null
+            && (name.getPrefix() != null || name.getGiven() != null);
     }
 
     private static boolean hasNoName(PN name) {
-        return name == null || (name.getFamily() == null && name.getGiven() == null && name.getPrefix() == null);
+        return name == null
+            || (StringUtils.isBlank(name.getFamily())
+                && StringUtils.isBlank(name.getGiven())
+                && StringUtils.isBlank(name.getPrefix()));
     }
 
     private StringType getPractitionerGiven(String given) {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
@@ -59,6 +59,7 @@ public class AgentDirectoryMapperTest {
         assertEquals(PRACT_META_PROFILE, practitioner.getMeta().getProfile().getFirst().getValue());
         assertEquals(NameUse.OFFICIAL, practitioner.getNameFirstRep().getUse());
         assertEquals("Test", practitioner.getNameFirstRep().getFamily());
+        assertThat(practitioner.getNameFirstRep().getText()).isNull();
 
         var organization = (Organization) mappedAgents.get(1);
         assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG", organization.getId());
@@ -100,6 +101,7 @@ public class AgentDirectoryMapperTest {
         assertEquals(PRACT_META_PROFILE, practitioner.getMeta().getProfile().getFirst().getValue());
         assertEquals(NameUse.OFFICIAL, practitioner.getNameFirstRep().getUse());
         assertEquals("Test", practitioner.getNameFirstRep().getFamily());
+        assertThat(practitioner.getNameFirstRep().getText()).isNull();
 
         var organization = (Organization) mappedAgents.get(1);
         assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG", organization.getId());
@@ -128,6 +130,7 @@ public class AgentDirectoryMapperTest {
         assertEquals(PRACT_META_PROFILE, practitioner.getMeta().getProfile().getFirst().getValue());
         assertEquals(NameUse.OFFICIAL, practitioner.getNameFirstRep().getUse());
         assertEquals("Test", practitioner.getNameFirstRep().getFamily());
+        assertThat(practitioner.getNameFirstRep().getText()).isNull();
 
         var organization = (Organization) mappedAgents.get(1);
         assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG", organization.getId());
@@ -158,6 +161,43 @@ public class AgentDirectoryMapperTest {
         assertEquals("Test", practitioner.getNameFirstRep().getFamily());
         assertThat(practitioner.getNameFirstRep().getGiven()).isEmpty();
         assertThat(practitioner.getNameFirstRep().getPrefix()).isEmpty();
+        assertThat(practitioner.getNameFirstRep().getText()).isNull();
+    }
+
+
+    @Test
+    public void mapAgentDirectoryOnlyAgentPersonWithoutFamilyNameElement() {
+        var agentDirectoryXml = """
+            <agentDirectory xmlns="urn:hl7-org:v3" classCode="AGNT">
+                <part typeCode="PART">
+                    <Agent classCode="AGNT">
+                        <id root="95D00D99-0601-4A8E-AD1D-1B564307B0A6"/>
+                        <agentPerson classCode="PSN" determinerCode="INSTANCE">
+                            <name>
+                                <prefix>Mr</prefix>
+                                <given>NHS</given>
+                            </name>
+                        </agentPerson>
+                    </Agent>
+                </part>
+            </agentDirectory>""";
+        var agentDirectory = unmarshallAgentDirectoryFromXmlString(agentDirectoryXml);
+
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+
+        assertThat(mappedAgents).hasSize(1);
+
+        var practitioner = (Practitioner) mappedAgents.getFirst();
+
+        assertAll(
+            () -> assertThat(practitioner.getId()).isEqualTo("95D00D99-0601-4A8E-AD1D-1B564307B0A6"),
+            () -> assertThat(practitioner.getMeta().getProfile().getFirst().getValue()).isEqualTo(PRACT_META_PROFILE),
+            () -> assertThat(practitioner.getNameFirstRep().getUse()).isEqualTo(NameUse.OFFICIAL),
+            () -> assertThat(practitioner.getNameFirstRep().getFamily()).isNull(),
+            () -> assertThat(practitioner.getNameFirstRep().getGiven()).isEmpty(),
+            () -> assertThat(practitioner.getNameFirstRep().getPrefix()).isEmpty(),
+            () -> assertThat(practitioner.getNameFirstRep().getText()).isEqualTo("Mr NHS")
+        );
     }
 
     @Test
@@ -173,9 +213,10 @@ public class AgentDirectoryMapperTest {
         assertThat(practitioner.getId()).isEqualTo("95D00D99-0601-4A8E-AD1D-1B564307B0A6");
         assertThat(practitioner.getMeta().getProfile().getFirst().getValue()).isEqualTo(PRACT_META_PROFILE);
         assertThat(practitioner.getNameFirstRep().getUse()).isEqualTo(NameUse.OFFICIAL);
-        assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("Unknown");
+        assertThat(practitioner.getNameFirstRep().getFamily()).isNull();
         assertThat(practitioner.getNameFirstRep().getGiven()).isEmpty();
         assertThat(practitioner.getNameFirstRep().getPrefix()).isEmpty();
+        assertThat(practitioner.getNameFirstRep().getText()).isEqualTo("Unknown");
     }
 
     @Test
@@ -199,9 +240,10 @@ public class AgentDirectoryMapperTest {
 
         assertAll(
             () -> assertThat(practitioner.getNameFirstRep().getUse()).isEqualTo(NameUse.OFFICIAL),
-            () -> assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("Unknown"),
+            () -> assertThat(practitioner.getNameFirstRep().getFamily()).isNull(),
             () -> assertThat(practitioner.getNameFirstRep().getGiven()).isEmpty(),
-            () -> assertThat(practitioner.getNameFirstRep().getPrefix()).isEmpty()
+            () -> assertThat(practitioner.getNameFirstRep().getPrefix()).isEmpty(),
+            () -> assertThat(practitioner.getNameFirstRep().getText()).isEqualTo("Unknown")
         );
     }
 
@@ -220,6 +262,7 @@ public class AgentDirectoryMapperTest {
         assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("Test");
         assertThat(practitioner.getNameFirstRep().getGiven().getFirst().getValue()).isEqualTo("NHS");
         assertThat(practitioner.getNameFirstRep().getPrefix().getFirst().getValue()).isEqualTo("Mr");
+        assertThat(practitioner.getNameFirstRep().getText()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## What

* Add assertions to existing tests to ensure that name.text is notset when the family name is present.
* Update existing tests and functionality to ensure that `name.text` is set to `Unknown` when there is either no `name` provided or the `name` fields are empty.
* Add tests and functionality to ensure that when `name.family` is not provided but other `name` fields are, then the `text` value is a concatenation of the available name fields. Also ensuring that the other `HumanName` fields are not set.

## Why

[Practioner.name.family cardinality has been relaxed to optional](https://simplifier.net/guide/gp-connect-access-record-structured/Home/Introduction/Release-notes?version=current#1.6.2:~:text=Practitioner.name.family%20cardinality%20has%20been%20relaxed%20to%20optional)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]
[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation