### PR TITLE
NIAD-3371: Document Reference not marked with a Security Label

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapper.java
@@ -88,7 +88,7 @@ public class DocumentReferenceMapper extends AbstractMapper<DocumentReference> {
 
         documentReference.addIdentifier(buildIdentifier(id, organization.getIdentifierFirstRep().getValue()));
         documentReference.setId(id);
-        documentReference.setMeta(generateMeta(narrativeStatement));
+        documentReference.setMeta(generateMeta(ehrComposition, narrativeStatement));
         documentReference.setStatus(DocumentReferenceStatus.CURRENT);
         documentReference.setType(getType(narrativeStatement));
         documentReference.setSubject(new Reference(patient));
@@ -115,7 +115,7 @@ public class DocumentReferenceMapper extends AbstractMapper<DocumentReference> {
         return documentReference;
     }
 
-    private Meta generateMeta(RCMRMT030101UKNarrativeStatement narrativeStatement) {
+    private Meta generateMeta(RCMRMT030101UKEhrComposition ehrComposition, RCMRMT030101UKNarrativeStatement narrativeStatement) {
         final RCMRMT030101UKExternalDocument externalDocument = narrativeStatement
             .getReference()
             .getFirst()
@@ -123,6 +123,8 @@ public class DocumentReferenceMapper extends AbstractMapper<DocumentReference> {
 
         return confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
             META_PROFILE,
+            ehrComposition.getConfidentialityCode(),
+            narrativeStatement.getConfidentialityCode(),
             externalDocument.getConfidentialityCode()
         );
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapperTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -123,6 +124,8 @@ class DocumentReferenceMapperTest {
         List<DocumentReference> documentReferences = documentReferenceMapper.mapResources(ehrExtract, createPatient(),
             getEncounterList(), AUTHOR_ORG, createAttachmentList());
         var documentReference = documentReferences.getFirst();
+
+        when(confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(anyString(), any())).thenCallRealMethod();
 
         assertAttachmentData(documentReference);
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapperTest.java
@@ -100,7 +100,31 @@ class DocumentReferenceMapperTest {
     }
 
     @Test
+    void mapNarrativeStatementToDocumentReferenceWithNopatSecurity() {
+
+        final Meta stubbedMeta = MetaUtil.getMetaFor(META_WITH_SECURITY, META_PROFILE);
+        Mockito
+            .lenient()
+            .when(confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
+                any(String.class), any(Optional.class), any(Optional.class), any(Optional.class))).thenReturn(stubbedMeta);
+
+        var ehrExtract = unmarshallEhrExtract("narrative_statement_has_referred_to_external_document_with_optional_data.xml");
+        List<DocumentReference> documentReferences = documentReferenceMapper.mapResources(ehrExtract, createPatient(),
+                                                                                          getEncounterList(),
+                                                                                          AUTHOR_ORG,
+                                                                                          createAttachmentList());
+        var documentReference = documentReferences.getFirst();
+
+        assertAll(
+            () -> documentReferences.forEach(this::assertMetaHasSecurity),
+            () -> assertOptionalValidData(documentReference)
+        );
+
+    }
+
+    @Test
     void mapNarrativeStatementToDocumentReferenceWithOptionalData() {
+
         var ehrExtract = unmarshallEhrExtract("narrative_statement_has_referred_to_external_document_with_optional_data.xml");
         List<DocumentReference> documentReferences = documentReferenceMapper.mapResources(ehrExtract, createPatient(),
             getEncounterList(), AUTHOR_ORG, createAttachmentList());
@@ -111,6 +135,7 @@ class DocumentReferenceMapperTest {
 
     @Test
     void mapMultipleNarrativeStatementToDocumentReference() {
+
         var ehrExtract = unmarshallEhrExtract("multiple_narrative_statements_has_referred_to_external_document.xml");
         List<DocumentReference> documentReferences = documentReferenceMapper.mapResources(ehrExtract, createPatient(),
             getEncounterList(), AUTHOR_ORG, createAttachmentList());

--- a/gp2gp-translator/src/test/resources/xml/DocumentReference/narrative_statement_has_referred_to_external_document.xml
+++ b/gp2gp-translator/src/test/resources/xml/DocumentReference/narrative_statement_has_referred_to_external_document.xml
@@ -10,6 +10,7 @@
                 <ehrComposition classCode="COMPOSITION" moodCode="EVN">
                     <id root="62A39454-299F-432E-993E-5A6232B4E099"/>
                     <availabilityTime value="20190708143500"/>
+                    <confidentialityCode code="NOPAT" codeSystem="2.16.840.1.113883.4.642.3.47" displayName="no disclosure to patient, family or caregivers without attending provider&apos;s authorization"/>
                     <author typeCode="AUT" contextControlCode="OP">
                         <time value="20100114" />
                         <agentRef classCode="AGNT">


### PR DESCRIPTION
## What

Redaction added to documents attached to the patient’s profile 

## Why

When  a consultation, which includes an attached document (e.g. PDF, DOC), marked  with a redaction tag then the confidentiality code should be added to DocumentReference resource.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation