### PR TITLE
NIAD-3196 - Changed the default value when it's a minor condition.

### DIFF
--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP10-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP10-output.json
@@ -3523,7 +3523,7 @@
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       },
       "note": [ {
-        "text": "Unspecified Significance: Defaulted to Minor"
+        "text": "Defaulted to Minor"
       }, {
         "text": "Active Problem, Not Significant (Minor)"
       } ]

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP11-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP11-output.json
@@ -4270,7 +4270,7 @@
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       },
       "note": [ {
-        "text": "Unspecified Significance: Defaulted to Minor"
+        "text": "Defaulted to Minor"
       }, {
         "text": "This is the third problem"
       }, {
@@ -4575,7 +4575,7 @@
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       },
       "note": [ {
-        "text": "Unspecified Significance: Defaulted to Minor"
+        "text": "Defaulted to Minor"
       }, {
         "text": "This is a strabismus note"
       }, {
@@ -4669,7 +4669,7 @@
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       },
       "note": [ {
-        "text": "Unspecified Significance: Defaulted to Minor"
+        "text": "Defaulted to Minor"
       }, {
         "text": "Inactive Problem, Not Significant (Minor)"
       } ]
@@ -4828,7 +4828,7 @@
       "note": [ {
         "text": "Defaulted status to active : Unknown status at source"
       }, {
-        "text": "Unspecified Significance: Defaulted to Minor"
+        "text": "Defaulted to Minor"
       }, {
         "text": "(Combined with [D]Difficulty in swallowing)"
       }, {
@@ -4903,7 +4903,7 @@
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       },
       "note": [ {
-        "text": "Unspecified Significance: Defaulted to Minor"
+        "text": "Defaulted to Minor"
       }, {
         "text": "Inactive Problem, Not Significant (Minor)"
       } ]

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
@@ -8564,7 +8564,7 @@
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       },
       "note": [ {
-        "text": "Unspecified Significance: Defaulted to Minor"
+        "text": "Defaulted to Minor"
       }, {
         "text": "Drug Allergy - Apsrin"
       }, {

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP3-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP3-output.json
@@ -1215,7 +1215,7 @@
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       },
       "note": [ {
-        "text": "Unspecified Significance: Defaulted to Minor"
+        "text": "Defaulted to Minor"
       }, {
         "text": "Inactive Problem, Not Significant (Minor)"
       } ]
@@ -1280,7 +1280,7 @@
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       },
       "note": [ {
-        "text": "Unspecified Significance: Defaulted to Minor"
+        "text": "Defaulted to Minor"
       }, {
         "text": "This is a note for anitbiotic allergy NOS"
       }, {
@@ -1475,7 +1475,7 @@
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       },
       "note": [ {
-        "text": "Unspecified Significance: Defaulted to Minor"
+        "text": "Defaulted to Minor"
       }, {
         "text": "Inactive Problem, Not Significant (Minor)"
       } ]
@@ -1658,7 +1658,7 @@
       "note": [ {
         "text": "Defaulted status to active : Unknown status at source"
       }, {
-        "text": "Unspecified Significance: Defaulted to Minor"
+        "text": "Defaulted to Minor"
       }, {
         "text": "What does this really mean?"
       }, {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapper.java
@@ -76,7 +76,7 @@ public class ConditionMapper extends AbstractMapper<Condition> {
     private static final String CLINICAL_STATUS_ACTIVE_CODE = "394774009";
     private static final String CLINICAL_STATUS_INACTIVE_CODE = "394775005";
     private static final String DEFAULT_CLINICAL_STATUS = "Defaulted status to active : Unknown status at source";
-    private static final String DEFAULT_ANNOTATION = "Unspecified Significance: Defaulted to Minor";
+    private static final String DEFAULT_ANNOTATION = "Defaulted to Minor";
     private static final String MAJOR_CODE_NAME = "major";
     private static final String MINOR_CODE_NAME = "minor";
     private static final String HIERARCHY_TYPE_PARENT = "parent";

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapperTest.java
@@ -396,6 +396,20 @@ class ConditionMapperTest {
         assertThat(conditions).isEmpty();
     }
 
+    @Test
+    void When_MappingLinksetWithNotMajorCode_Expect_DefaultedToMinor(){
+        final var ehrExtract = unmarshallEhrExtract(
+                "Condition",
+                "linkset_with_minor_severity_code.xml"
+        );
+
+        final List<Condition> conditions = conditionMapper.mapResources(ehrExtract, patient, List.of(), PRACTISE_CODE);
+
+        assertThat(conditions).isNotEmpty();
+        assertThat(conditions.getFirst().getNote().getFirst().getText()).isEqualTo("Defaulted to Minor");
+
+    }
+
     private void addMedicationRequestsToBundle(Bundle bundle) {
         var planMedicationRequest = new MedicationRequest().setId(AUTHORISE_ID);
         var orderMedicationRequest = new MedicationRequest().setId(PRESCRIBE_ID);

--- a/gp2gp-translator/src/test/resources/xml/Condition/linkset_with_minor_severity_code.xml
+++ b/gp2gp-translator/src/test/resources/xml/Condition/linkset_with_minor_severity_code.xml
@@ -1,0 +1,49 @@
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <availabilityTime value="20101209114846"/>
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <id root="EHR_COMPOSITION_ENCOUNTER_ID"/>
+                    <Participant2 typeCode="PRF" contextControlCode="OP">
+                        <agentRef classCode="AGNT">
+                            <id root="ASSERTER_ID"/>
+                        </agentRef>
+                    </Participant2>
+                    <component typeCode="COMP">
+                        <LinkSet classCode="OBS" moodCode="EVN">
+                            <id root="LINKSET_ID"/>
+                            <code code="394774009" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Active problem">
+                                <originalText>Active Problem, Minor</originalText>
+                                <qualifier inverted="false">
+                                    <name code="123456789" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Minor" />
+                                </qualifier>
+                            </code>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <low value="20101209000000"/>
+                                <high value="20101209000000"/>
+                            </effectiveTime>
+                            <availabilityTime value="20101209114846"/>
+                            <component typeCode="COMP">
+                                <statementRef classCode="OBS" moodCode="EVN">
+                                    <id root="STATEMENT_REF_ID"/>
+                                </statementRef>
+                            </component>
+                            <component typeCode="COMP">
+                                <statementRef classCode="OBS" moodCode="EVN">
+                                    <id root="STATEMENT_REF_ID_1"/>
+                                </statementRef>
+                            </component>
+                            <conditionNamed typeCode="NAME" inversionInd="true">
+                                <namedStatementRef classCode="OBS" moodCode="EVN">
+                                    <id root="NAMED_STATEMENT_REF_ID"/>
+                                </namedStatementRef>
+                            </conditionNamed>
+                        </LinkSet>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>


### PR DESCRIPTION
## What

Before, when the adaptor receives GP2GP xml and finds a problem that is either coded as ‘unspecified significance’ or no severity qualifier is present for the problem it outputs ‘Unspecified significance: Defaulted to Minor’. This change just outputs 'Defaulted to Minor'. 

## Why

A cosmetic request.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation