### PR TITLE
Fix jupiter dependencies and vulnerability

### DIFF
--- a/schema/build.gradle
+++ b/schema/build.gradle
@@ -12,11 +12,13 @@ dependencies {
     api 'com.sun.xml.bind:jaxb-impl:4.0.5'
     api 'com.sun.istack:istack-commons-runtime:4.2.0'
 
-    implementation 'org.apache.commons:commons-lang3:3.17.0'
+    implementation 'org.apache.commons:commons-lang3:3.18.0'
     implementation 'org.projectlombok:lombok:1.18.36'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.11.4'
+    testImplementation(platform('org.junit:junit-bom:5.13.4'))
+    testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.assertj:assertj-core:3.27.3'
+
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 test {


### PR DESCRIPTION
## What

* Use `junit-bom` to ensure package compatibility.
* Update commons-lang3 to resolve vulnerability.

## Why

Using `junit-bom` ensure that any junit dependencies versions are managed by the BOM and prevents dependabot from failing when it tries to update one junit dependency but not the other.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation