### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,13 @@ jobs:
     strategy:
       matrix:
         config:
-          - folder: gp2gp-translator
+          - folder: docker/gp2gp-translator
             dockerhub_name: nia-ps-adaptor
-          - folder: gpc-facade
+          - folder: docker/gpc-facade
             dockerhub_name: nia-ps-facade
-          - folder: db-migration
+          - folder: docker/db-migration
             dockerhub_name: nia-ps-db-migration
-          - folder: snomed-schema
+          - folder: docker/snomed-schema
             dockerhub_name: nia-ps-snomed-schema
 
     uses: NHSDigital/integration-adaptor-actions/.github/workflows/release-adaptor-container-image.yml@main


### PR DESCRIPTION

## What

* Prefix matrix.config.folder with `docker/` to ensure the correct folder is resolved.

## Why

As the shared action now deals with repositories where there is not a separate docker folder, it is now necessary to specify the docker folder when providing the inputs to the release-adaptor-container-image reusable workflow

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation